### PR TITLE
Multithreaded downloader

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -154,7 +154,7 @@ class Downloader:
     def _media_progress(self, saved, total):
         pass
 
-    def _media_callback(self, media):
+    def _media_callback(self, media, bar):
         """
         Simple callback to download media from (location, filename, file_size).
         """
@@ -162,19 +162,20 @@ class Downloader:
         os.makedirs(os.path.dirname(file), exist_ok=True)
         self.client.download_file(location, file=file, file_size=file_size)
 
-    def _users_callback(self, user):
+    def _users_callback(self, user, bar):
         """
         Simple callback to retrieve a full user and dump it into the dumper.
         """
         self._dump_full_entity(self.client(
             functions.users.GetFullUserRequest(user)
         ))
-        return 1
+        bar.update(1)
 
-    def _chats_callback(self, chat):
+    def _chats_callback(self, chat, bar):
         """
         Simple callback to retrieve a full channel and dump it into the dumper.
         """
+        n = 1
         if isinstance(chat, types.Chat):
             self._dump_full_entity(chat)
         elif isinstance(chat, types.Channel):
@@ -182,8 +183,8 @@ class Downloader:
                 functions.channels.GetFullChannelRequest(chat)
             ))
         else:
-            return 0
-        return 1
+            n = 0
+        bar.update(n)
 
     def enqueue_entities(self, entities):
         """
@@ -307,9 +308,7 @@ class Downloader:
             if item is None:
                 break
             else:
-                n = callback(item)
-                if bar:
-                    bar.update(n or 0)
+                callback(item, bar)
             # Sleep 'sleep_wait' time, considering the time it took
             # to invoke this request (delta between now and start).
             time.sleep(max(sleep_wait - (time.time() - start), 0))

--- a/downloader.py
+++ b/downloader.py
@@ -232,7 +232,9 @@ class Downloader:
 
         elif isinstance(media, (types.Photo,
                                 types.UserProfilePhoto, types.ChatPhoto)):
-            # TODO Check that chatphoto is allowed
+            if 'chatphoto' not in self.types:
+                return
+
             if isinstance(media, types.Photo):
                 date = media.date
                 known_id = known_id or media.id

--- a/downloader.py
+++ b/downloader.py
@@ -5,9 +5,10 @@ import logging
 import mimetypes
 import os
 import queue
+import re
 import threading
 import time
-from collections import deque, defaultdict
+from collections import defaultdict
 
 import tqdm
 from telethon import utils
@@ -23,7 +24,8 @@ __log__ = logging.getLogger(__name__)
 VALID_TYPES = {
     'photo', 'document', 'video', 'audio', 'sticker', 'voice', 'chatphoto'
 }
-BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}/{remaining}, {rate_noinv_fmt}{postfix}]"
+BAR_FORMAT = "{l_bar}{bar}| {n_fmt}/{total_fmt} " \
+             "[{elapsed}/{remaining}, {rate_noinv_fmt}{postfix}]"
 
 
 QUEUE_TIMEOUT = 5
@@ -609,8 +611,8 @@ class Downloader:
     def load_entities_from_str(self, string):
         """Helper function to load entities from the config file"""
         for who in string.split(','):
-            who = who.strip().split(':', 1)[0]  # Ignore anything after ':'
-            if (not who.startswith('+') and who.isdigit()) or who.startswith('-'):
+            who = who.split(':', 1)[0].strip()  # Ignore anything after ':'
+            if re.match(r'[^+]-?\d+', who):
                 yield self.client.get_input_entity(int(who))
             else:
                 yield self.client.get_input_entity(who)

--- a/downloader.py
+++ b/downloader.py
@@ -140,43 +140,6 @@ class Downloader:
                     self._channel_queue.put(entity)
             # Drop UserEmpty, ChatEmpty, ChatForbidden and ChannelForbidden
 
-    @staticmethod
-    def _get_file_location(media):
-        location = file_size = None
-        if isinstance(media, types.MessageMediaPhoto):
-            media = media.photo
-
-        if isinstance(media, types.Photo):
-            for size in reversed(media.sizes):
-                if isinstance(size, types.PhotoSize):
-                    if isinstance(size.location, types.FileLocation):
-                        file_size = size.size
-                        location = size.location
-                        break
-        elif isinstance(media, types.MessageMediaDocument):
-            if isinstance(media.document, types.Document):
-                file_size = media.document.size
-                location = types.InputDocumentFileLocation(
-                    id=media.document.id,
-                    access_hash=media.document.access_hash,
-                    version=media.document.access_hash
-                )
-        elif isinstance(media, (types.UserProfilePhoto, types.ChatPhoto)):
-            file_size = 48 * 1024  # Average
-            if isinstance(media.photo_big, types.FileLocation):
-                location = media.photo_big
-            elif isinstance(media.photo_small, types.FileLocation):
-                location = media.photo_small
-
-        if isinstance(location, types.FileLocation):
-            location = types.InputFileLocation(
-                volume_id=location.volume_id,
-                local_id=location.local_id,
-                secret=location.secret
-            )
-
-        return location, file_size
-
     def enqueue_media(self, media, from_entity, known_id=None):
         if isinstance(media, types.Message):
             msg = media
@@ -184,7 +147,7 @@ class Downloader:
                 return
 
             media = msg.media
-            location, file_size = self._get_file_location(media)
+            location, file_size = export_utils.get_file_location(media)
             if not location:
                 return
 
@@ -226,7 +189,7 @@ class Downloader:
                 date = datetime.datetime.now()
                 known_id = utils.get_peer_id(self.target)
 
-            location, file_size = self._get_file_location(media)
+            location, file_size = export_utils.get_file_location(media)
             formatter = defaultdict(
                 str,
                 id=known_id,

--- a/downloader.py
+++ b/downloader.py
@@ -140,6 +140,43 @@ class Downloader:
                     self._channel_queue.put(entity)
             # Drop UserEmpty, ChatEmpty, ChatForbidden and ChannelForbidden
 
+    @staticmethod
+    def _get_file_location(media):
+        location = file_size = None
+        if isinstance(media, types.MessageMediaPhoto):
+            media = media.photo
+
+        if isinstance(media, types.Photo):
+            for size in reversed(media.sizes):
+                if isinstance(size, types.PhotoSize):
+                    if isinstance(size.location, types.FileLocation):
+                        file_size = size.size
+                        location = size.location
+                        break
+        elif isinstance(media, types.MessageMediaDocument):
+            if isinstance(media.document, types.Document):
+                file_size = media.document.size
+                location = types.InputDocumentFileLocation(
+                    id=media.document.id,
+                    access_hash=media.document.access_hash,
+                    version=media.document.access_hash
+                )
+        elif isinstance(media, (types.UserProfilePhoto, types.ChatPhoto)):
+            file_size = 48 * 1024  # Average
+            if isinstance(media.photo_big, types.FileLocation):
+                location = media.photo_big
+            elif isinstance(media.photo_small, types.FileLocation):
+                location = media.photo_small
+
+        if isinstance(location, types.FileLocation):
+            location = types.InputFileLocation(
+                volume_id=location.volume_id,
+                local_id=location.local_id,
+                secret=location.secret
+            )
+
+        return location, file_size
+
     def enqueue_media(self, media, from_entity, known_id=None):
         if isinstance(media, types.Message):
             msg = media
@@ -147,28 +184,7 @@ class Downloader:
                 return
 
             media = msg.media
-            location = file_size = None
-            if isinstance(media, types.MessageMediaPhoto):
-                if isinstance(media.photo, types.Photo):
-                    for size in reversed(media.photo.sizes):
-                        if isinstance(size, types.PhotoSize):
-                            if isinstance(size.location, types.FileLocation):
-                                file_size = size.size
-                                # TODO Telethon needs autocast...
-                                location = types.InputFileLocation(
-                                    volume_id=size.location.volume_id,
-                                    local_id=size.location.local_id,
-                                    secret=size.location.secret
-                                )
-                                break
-            elif isinstance(media, types.MessageMediaDocument):
-                if isinstance(media.document, types.Document):
-                    file_size = media.document.size
-                    location = types.InputDocumentFileLocation(
-                        id=media.document.id,
-                        access_hash=media.document.access_hash,
-                        version=media.document.access_hash
-                    )
+            location, file_size = self._get_file_location(media)
             if not location:
                 return
 
@@ -203,36 +219,14 @@ class Downloader:
 
         elif isinstance(media, (types.Photo,
                                 types.UserProfilePhoto, types.ChatPhoto)):
-            date = datetime.datetime.now()
-            file_size = None
-            location = None
-            if isinstance(media, (types.UserProfilePhoto, types.ChatPhoto)):
-                if isinstance(media.photo_big, types.FileLocation):
-                    location = media.photo_big
-                elif isinstance(media.photo_small, types.FileLocation):
-                    location = media.photo_small
-            elif isinstance(media, types.Photo):
+            if isinstance(media, types.Photo):
                 date = media.date
                 known_id = media.id
-                for size in reversed(media.sizes):
-                    if isinstance(size, types.PhotoSize):
-                        if isinstance(size.location, types.FileLocation):
-                            file_size = size.size
-                            location = size.location
-                            break
-
-            if not location:
-                return
             else:
-                location = types.InputFileLocation(
-                    volume_id=location.volume_id,
-                    local_id=location.local_id,
-                    secret=location.secret
-                )
-
-            if known_id is None:
+                date = datetime.datetime.now()
                 known_id = utils.get_peer_id(self.target)
 
+            location, file_size = self._get_file_location(media)
             formatter = defaultdict(
                 str,
                 id=known_id,

--- a/downloader.py
+++ b/downloader.py
@@ -7,11 +7,13 @@ import os
 import time
 from collections import deque, defaultdict
 
+import tqdm
 from telethon import utils
 from telethon.errors import ChatAdminRequiredError
 from telethon.extensions import BinaryReader
 from telethon.tl import types, functions
-import tqdm
+
+import utils as export_utils
 
 __log__ = logging.getLogger(__name__)
 
@@ -187,34 +189,6 @@ class Downloader:
         if self.types:
             self.types.add('unknown')  # Always allow "unknown" media types
 
-    @staticmethod
-    def _get_media_type(media):
-        """
-        Returns the friendly type string for the given MessageMedia.
-        """
-        if not media:
-            return ''
-        if isinstance(media, types.MessageMediaPhoto):
-            return 'photo'
-        elif isinstance(media, types.MessageMediaDocument):
-            if not isinstance(media, types.Document):
-                return False
-            for attr in media.attributes:
-                if isinstance(attr, types.DocumentAttributeSticker):
-                    return 'sticker'
-                elif isinstance(attr, types.DocumentAttributeVideo):
-                    return 'video'
-                elif isinstance(attr, types.DocumentAttributeAudio):
-                    if attr.voice:
-                        return 'voice'
-                    return 'audio'
-            return 'document'
-        return 'unknown'
-
-    @staticmethod
-    def _get_media_extension(media):
-        pass
-
     def check_media(self, media):
         """
         Checks whether the given MessageMedia should be downloaded or not.
@@ -223,7 +197,7 @@ class Downloader:
             return False
         if not self.types:
             return True
-        return self._get_media_type(media) in self.types
+        return export_utils.get_media_type(media) in self.types
 
     def download_media(self, msg, target_id, entities):
         """
@@ -248,7 +222,7 @@ class Downloader:
             context_id=target_id,
             sender_id=msg.from_id or 0,
             ext=utils.get_extension(media) or '.bin',
-            type=self._get_media_type(media) or 'unknown',
+            type=export_utils.get_media_type(media) or 'unknown',
             name=utils.get_display_name(entities[target_id]) or 'unknown',
             sender_name=utils.get_display_name(
                 entities.get(msg.from_id)) or 'unknown'

--- a/downloader.py
+++ b/downloader.py
@@ -184,10 +184,10 @@ class Downloader:
                                 types.UserProfilePhoto, types.ChatPhoto)):
             if isinstance(media, types.Photo):
                 date = media.date
-                known_id = media.id
+                known_id = known_id or media.id
             else:
                 date = datetime.datetime.now()
-                known_id = utils.get_peer_id(self.target)
+                known_id = known_id or utils.get_peer_id(self.target)
 
             location, file_size = export_utils.get_file_location(media)
             formatter = defaultdict(

--- a/downloader.py
+++ b/downloader.py
@@ -150,7 +150,7 @@ class Downloader:
             location = file_size = None
             if isinstance(media, types.MessageMediaPhoto):
                 if isinstance(media.photo, types.Photo):
-                    for size in media.photo.sizes:
+                    for size in reversed(media.photo.sizes):
                         if isinstance(size, types.PhotoSize):
                             if isinstance(size.location, types.FileLocation):
                                 file_size = size.size
@@ -214,7 +214,7 @@ class Downloader:
             elif isinstance(media, types.Photo):
                 date = media.date
                 known_id = media.id
-                for size in media.sizes:
+                for size in reversed(media.sizes):
                     if isinstance(size, types.PhotoSize):
                         if isinstance(size.location, types.FileLocation):
                             file_size = size.size

--- a/downloader.py
+++ b/downloader.py
@@ -345,8 +345,9 @@ class Downloader:
                          initial=found, bar_format=BAR_FORMAT)
         entbar = tqdm.tqdm(unit=' entities', bar_format=BAR_FORMAT,
                            postfix={'chat': utils.get_display_name(target)})
-        medbar = tqdm.tqdm(unit='b', bar_format=BAR_FORMAT, unit_scale=True,
-                           postfix={'media': 'file size'})
+        medbar = tqdm.tqdm(unit='B', unit_divisor=1024, unit_scale=True,
+                           bar_format=BAR_FORMAT, postfix={'media': 'saved'})
+
         medbar.total = 0
 
         threads = [

--- a/dumper.py
+++ b/dumper.py
@@ -434,27 +434,12 @@ class Dumper:
                 row['secret'] = 0
 
         elif isinstance(media, types.MessageMediaDocument):
-            row['type'] = 'document'
+            row['type'] = utils.get_media_type(media)
             doc = media.document
             if isinstance(doc, types.Document):
                 row['mime_type'] = doc.mime_type
                 row['size'] = doc.size
                 row['thumbnail_id'] = self.dump_media(doc.thumb)
-                subtype = None
-                for attr in doc.attributes:
-                    if isinstance(attr, types.DocumentAttributeFilename):
-                        row['name'] = attr.file_name
-                    elif isinstance(attr, types.DocumentAttributeAudio):
-                        subtype = 'audio'
-                    elif isinstance(attr, types.DocumentAttributeVideo):
-                        subtype = 'video'
-                    elif isinstance(attr, types.DocumentAttributeSticker):
-                        subtype = 'sticker'
-                    elif isinstance(attr, types.DocumentAttributeAnimated):
-                        subtype = 'animated'
-                if subtype:
-                    row['type'] += '.' + subtype
-
                 row['local_id'] = doc.id
                 row['volume_id'] = doc.version
                 row['secret'] = doc.access_hash

--- a/dumper.py
+++ b/dumper.py
@@ -55,12 +55,12 @@ class Dumper:
         """
         self.config = config
         if 'DBFileName' in self.config:
-            if self.config["DBFileName"] == ':memory:':
-                self.conn = sqlite3.connect(':memory:')
-            else:
-                filename = os.path.join(self.config['OutputDirectory'],
-                                        self.config['DBFileName'])
-                self.conn = sqlite3.connect('{}.db'.format(filename))
+            where = self.config["DBFileName"]
+            if where != ':memory:':
+                where = '{}.db'.format(os.path.join(
+                    self.config['OutputDirectory'], self.config['DBFileName']
+                ))
+            self.conn = sqlite3.connect(where, check_same_thread=False)
         else:
             logger.error("A database filename is required!")
             exit()

--- a/telegram_export.py
+++ b/telegram_export.py
@@ -236,7 +236,7 @@ def main():
     if args.list_dialogs or args.search_string:
         return list_or_search_dialogs(args, client)
 
-    downloader = Downloader(client, config['Dumper'])
+    downloader = Downloader(client, config['Dumper'], dumper)
     cache_file = os.path.join(absolute_session_name + '.tl')
     try:
         if args.download_past_media:
@@ -250,7 +250,7 @@ def main():
                 dumper.config['Whitelist']
             )
             for who in entities:
-                downloader.save_messages(dumper, who)
+                downloader.start(who)
 
         elif 'Blacklist' in dumper.config:
             # May be blacklist, so save the IDs on who to avoid
@@ -260,11 +260,11 @@ def main():
             avoid = set(utils.get_peer_id(x) for x in entities)
             for entity in downloader.fetch_dialogs(cache_file=cache_file):
                 if utils.get_peer_id(entity) not in avoid:
-                    downloader.save_messages(dumper, entity)
+                    downloader.start(entity)
         else:
             # Neither blacklist nor whitelist - get all
             for entity in downloader.fetch_dialogs(cache_file=cache_file):
-                downloader.save_messages(dumper, entity)
+                downloader.start(entity)
 
     except KeyboardInterrupt:
         pass

--- a/telegram_export.py
+++ b/telegram_export.py
@@ -205,6 +205,16 @@ def list_or_search_dialogs(args, client):
     client.disconnect()
 
 
+def entities_from_str(client, string):
+    """Helper function to load entities from the config file"""
+    for who in string.split(','):
+        who = who.split(':', 1)[0].strip()  # Ignore anything after ':'
+        if re.match(r'[^+]-?\d+', who):
+            yield client.get_input_entity(int(who))
+        else:
+            yield client.get_input_entity(who)
+
+
 def main():
     """The main telegram-export program.
        Goes through the configured dialogs and dumps them into the database"""
@@ -246,24 +256,21 @@ def main():
         dumper.check_self_user(client.get_me(input_peer=True).user_id)
         if 'Whitelist' in dumper.config:
             # Only whitelist, don't even get the dialogs
-            entities = downloader.load_entities_from_str(
-                dumper.config['Whitelist']
-            )
+            entities = entities_from_str(client, dumper.config['Whitelist'])
             for who in entities:
                 downloader.start(who)
 
         elif 'Blacklist' in dumper.config:
             # May be blacklist, so save the IDs on who to avoid
-            entities = downloader.load_entities_from_str(
-                dumper.config['Blacklist']
-            )
+            entities = entities_from_str(client, dumper.config['Blacklist'])
             avoid = set(utils.get_peer_id(x) for x in entities)
-            for entity in downloader.fetch_dialogs(cache_file=cache_file):
-                if utils.get_peer_id(entity) not in avoid:
-                    downloader.start(entity)
+            # TODO Should this get_dialogs call be cached? How?
+            for dialog in client.get_dialogs(limit=None):
+                if utils.get_peer_id(dialog.entity) not in avoid:
+                    downloader.start(dialog.entity)
         else:
             # Neither blacklist nor whitelist - get all
-            for entity in downloader.fetch_dialogs(cache_file=cache_file):
+            for entity in client.get_dialogs(limit=None):
                 downloader.start(entity)
 
     except KeyboardInterrupt:

--- a/tests.py
+++ b/tests.py
@@ -111,7 +111,7 @@ class TestDumpAll(unittest.TestCase):
         )
 
         self.client(functions.messages.DeleteHistoryRequest('me', 0))
-        downloader = Downloader(self.client, self.dumper_config)
+        downloader = Downloader(self.client, self.dumper_config, dumper)
 
         which = 1
         for amount, what in actions:
@@ -125,7 +125,7 @@ class TestDumpAll(unittest.TestCase):
                 print('Dumping', amount, 'messages...')
                 chunks = (amount + dumper.chunk_size - 1) // dumper.chunk_size
                 dumper.max_chunks = chunks
-                downloader.save_messages(dumper, 'me')
+                downloader.start('me')
 
         messages = self.client.get_message_history('me', limit=None)
         print('Full history')

--- a/utils.py
+++ b/utils.py
@@ -92,6 +92,43 @@ def get_media_type(media):
     return 'unknown'
 
 
+def get_file_location(media):
+    location = file_size = None
+    if isinstance(media, types.MessageMediaPhoto):
+        media = media.photo
+
+    if isinstance(media, types.Photo):
+        for size in reversed(media.sizes):
+            if isinstance(size, types.PhotoSize):
+                if isinstance(size.location, types.FileLocation):
+                    file_size = size.size
+                    location = size.location
+                    break
+    elif isinstance(media, types.MessageMediaDocument):
+        if isinstance(media.document, types.Document):
+            file_size = media.document.size
+            location = types.InputDocumentFileLocation(
+                id=media.document.id,
+                access_hash=media.document.access_hash,
+                version=media.document.access_hash
+            )
+    elif isinstance(media, (types.UserProfilePhoto, types.ChatPhoto)):
+        file_size = 48 * 1024  # Average
+        if isinstance(media.photo_big, types.FileLocation):
+            location = media.photo_big
+        elif isinstance(media.photo_small, types.FileLocation):
+            location = media.photo_small
+
+    if isinstance(location, types.FileLocation):
+        location = types.InputFileLocation(
+            volume_id=location.volume_id,
+            local_id=location.local_id,
+            secret=location.secret
+        )
+
+    return location, file_size
+
+
 def action_to_name(action):
     """
     Returns a namespace'd "friendly" name for the given

--- a/utils.py
+++ b/utils.py
@@ -94,7 +94,7 @@ def get_media_type(media):
 
 def get_file_location(media):
     """
-    Helper method to turn arbitrary media into (InputFileLocation, ~size).
+    Helper method to turn arbitrary media into (InputFileLocation, size/None).
     """
     location = file_size = None
     if isinstance(media, types.MessageMediaPhoto):
@@ -116,7 +116,6 @@ def get_file_location(media):
                 version=media.document.access_hash
             )
     elif isinstance(media, (types.UserProfilePhoto, types.ChatPhoto)):
-        file_size = 48 * 1024  # Average
         if isinstance(media.photo_big, types.FileLocation):
             location = media.photo_big
         elif isinstance(media.photo_small, types.FileLocation):

--- a/utils.py
+++ b/utils.py
@@ -63,6 +63,35 @@ def decode_msg_entities(string):
     return parsed
 
 
+def get_media_type(media):
+    """
+    Returns a friendly type for the given media.
+    """
+    if not media:
+        return ''
+
+    if isinstance(media, types.MessageMediaPhoto):
+        return 'photo'
+
+    elif isinstance(media, types.MessageMediaDocument):
+        if isinstance(media, types.Document):
+            for attr in media.attributes:
+                if isinstance(attr, types.DocumentAttributeSticker):
+                    return 'document.sticker'
+                elif isinstance(attr, types.DocumentAttributeVideo):
+                    return 'document.video'
+                elif isinstance(attr, types.DocumentAttributeAnimated):
+                    return 'document.animated'
+                elif isinstance(attr, types.DocumentAttributeAudio):
+                    if attr.voice:
+                        return 'document.voice'
+                    else:
+                        return 'document.audio'
+        return 'document'
+
+    return 'unknown'
+
+
 def action_to_name(action):
     """
     Returns a namespace'd "friendly" name for the given

--- a/utils.py
+++ b/utils.py
@@ -93,6 +93,9 @@ def get_media_type(media):
 
 
 def get_file_location(media):
+    """
+    Helper method to turn arbitrary media into (InputFileLocation, ~size).
+    """
     location = file_size = None
     if isinstance(media, types.MessageMediaPhoto):
         media = media.photo


### PR DESCRIPTION
This allows to interlace different types of requests together in a way that makes it easy to specify a custom sleep for each of them.

I'm not particularly happy with the result because the whole class is really big and it feels rather messy, although I've tried to reuse as much code as I can. The idea is to keep a few queues (entities and media) that are filled through other requests (getting history and admin log) and N threads are spawned (one for each queue) running a reusable method that just pops items off the queue and calls a callback with them to do the actual work.

This middle man keeps track of the time and the needed sleep, and sleeps just enough (it takes into consideration how long the callbacks, or even getting an item from the queue, takes, so it only sleeps as much as it needs).

Still, the main loop is rather big (even after separating the dumping parts into their own methods so they are more manageable), but I guess it's necessary. Admin log and history are interlaced by hand because these, unlike entity dumpers, rely on an offset that varies over time. We would need a different approach to tackle this issue. Perhaps a class that also keeps track about when the requests can be executed and execute them. Once they're done (e.g. reached their respective ends), be removed from the class. However this gets trickier when resuming or variables that tell when to stop kick into play, and also optimally determining when to execute them. Not to mention the level of abstraction up to which we would be getting.

All in all the implemented approach seems pretty reusable since (if we ever move to asyncio) the loops to pop items off a queue are already implemented. It would be matter of replacing threads with an asynchronous task.

All accesses to the dumper are now guarded by a lock, and the time spent inside said lock has been kept as low as I could.