### PR TITLE
remove SecondFactorPassword parameter in settings

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -14,9 +14,6 @@ ApiHash = 0123456789abcdef0123456789abcdef
 # Your phone number. You must supply this. Should start with +country code eg +44.
 PhoneNumber = xxxxxxxxxx
 
-# Your 2FA password, if necessary. Leave commented if not.
-# SecondFactorPassword = xxxxxxxxxx
-
 # This can be anything
 ; SessionName = exporter
 SessionName = exporter

--- a/telegram_export/__main__.py
+++ b/telegram_export/__main__.py
@@ -285,7 +285,7 @@ async def main(loop):
     exporter = Exporter(client, config, dumper, loop)
 
     try:
-        if args.download_past_media:SecondFactorPassword
+        if args.download_past_media:
             await exporter.download_past_media()
         else:
             await exporter.start()

--- a/telegram_export/__main__.py
+++ b/telegram_export/__main__.py
@@ -271,22 +271,13 @@ async def main(loop):
         config['Dumper']['OutputDirectory'],
         config['TelegramAPI']['SessionName']
     )
-    if config.has_option('TelegramAPI', 'SecondFactorPassword'):
-        client = await (TelegramClient(
-                absolute_session_name,
-                config['TelegramAPI']['ApiId'],
-                config['TelegramAPI']['ApiHash'],
-                loop=loop,
-                proxy=proxy
-            ).start(config['TelegramAPI']['PhoneNumber'], password=config['TelegramAPI']['SecondFactorPassword']))
-    else:
-        client = await (TelegramClient(
-            absolute_session_name,
-            config['TelegramAPI']['ApiId'],
-            config['TelegramAPI']['ApiHash'],
-            loop=loop,
-            proxy=proxy
-        ).start(config['TelegramAPI']['PhoneNumber']))
+    client = await (TelegramClient(
+        absolute_session_name,
+        config['TelegramAPI']['ApiId'],
+        config['TelegramAPI']['ApiHash'],
+        loop=loop,
+        proxy=proxy
+    ).start(config['TelegramAPI']['PhoneNumber']))
 
     if args.list_dialogs or args.search_string:
         return await list_or_search_dialogs(args, client)
@@ -294,7 +285,7 @@ async def main(loop):
     exporter = Exporter(client, config, dumper, loop)
 
     try:
-        if args.download_past_media:
+        if args.download_past_media:SecondFactorPassword
             await exporter.download_past_media()
         else:
             await exporter.start()


### PR DESCRIPTION
Storing telegram's two factor authentication password in config file is not a logical thing to do since it's creating security issues for the user while Telethon handles the situation where the user has two factor authentication enabled. 
By removing this options telethon will ask for the user's password the same way it asks for the user's auth code and we don't create a security risk by storing user's password on disk