### PR TITLE
added types for scraping and fixed a bug that would make exporter to …

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -125,3 +125,7 @@ LibraryLogLevel = WARNING
 # Sets proxy support
 # Proxy = socks5://user:password@127.0.0.1:1080
 # Proxy = http://127.0.0.1:8080
+
+# Sets types which can be group, user or channel
+# Should be comma separated
+FromType = user, channel

--- a/telegram_export/__main__.py
+++ b/telegram_export/__main__.py
@@ -43,9 +43,11 @@ def load_config(filename):
     """Load config from the specified file and return the parsed config"""
     # Get a path to the file. If it was specified, it should be fine.
     # If it was not specified, assume it's config.ini in the script's dir.
-    config_dir = appdirs.user_config_dir("telegram-export")
+    if os.path.isfile('config.ini'):
+        filename = os.path.join(os.getcwd(), 'config.ini')
 
     if not filename:
+        config_dir = appdirs.user_config_dir("telegram-export")
         filename = os.path.join(config_dir, 'config.ini')
 
     if not os.path.isfile(filename):

--- a/telegram_export/utils.py
+++ b/telegram_export/utils.py
@@ -41,6 +41,12 @@ COMMON_MIME_TO_EXTENSION = {
     'video/mp4': '.mp4',  # To avoid ".m4v"
 }
 
+FROM_TYPES = {
+    'group': types.Chat,
+    'user': types.User,
+    'channel': types.Channel
+}
+
 
 def encode_msg_entities(entities):
     """


### PR DESCRIPTION
There was a bug related to "config.ini" file that would cause telegram-exporter to not work on macOS:
```
import: delegate library support not built-in '' (X11) @ error/import.c/ImportImageCommand/1297.
/Users/vahid/miniconda3/bin/telegram-export: line 2: syntax error near unexpected token `"telegram_export",'
/Users/vahid/miniconda3/bin/telegram-export: line 2: `runpy.run_module("telegram_export", run_name="__main__", alter_sys=True)'
```
I've added a condition to search for the "config.ini" file in the workspace and it solved the problem.

Also I've added type specification (channel, group, user) for exporting.